### PR TITLE
added jq and curl ( https://github.com/Terradue/Stars/issues/4 ) . Test:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bullseye-slim-amd64
 
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates \
+  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl \
   && rm -rf /var/lib/apt/lists/* /tmp/*
   
 WORKDIR /app


### PR DESCRIPTION
added jq and curl ( https://github.com/Terradue/Stars/issues/4 ) . Test:

(base) xxx@Micheles-MacBook-Pro Stars % docker build -t stars --build-arg DOCKER_DEFAULT_PLATFORM=linux/amd64 . Sending build context to Docker daemon 310.4MB
Step 1/16 : FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build .
.
Step 1/16 : FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build .
.
Step 13/16 : RUN apt-get update && apt-get upgrade -y && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl && rm -rf /var/lib/apt/lists/* /tmp/* ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested ---> Running in 079071ee7f9d
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB] Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB] Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB] Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8183 kB] Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [237 kB] Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.6 kB] Fetched 8643 kB in 8s (1127 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded. Reading package lists...
Building dependency tree...
Reading state information...
ca-certificates is already the newest version (20210119). libgssapi-krb5-2 is already the newest version (1.18.3-6+deb11u3). libssl1.1 is already the newest version (1.1.1n-0+deb11u4). The following additional packages will be installed: libaec0 libbrotli1 libcurl4 libhdf5-103-1 libhdf5-hl-100 libjq1 libldap-2.4-2 libldap-common libnghttp2-14 libonig5 libpsl5 librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libssh2-1 libsz2 publicsuffix
Suggested packages:
libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql The following NEW packages will be installed:
curl hdf5-tools jq libaec0 libbrotli1 libcurl4 libhdf5-103-1 libhdf5-hl-100 libjq1 libldap-2.4-2 libldap-common libnghttp2-14 libonig5 libpsl5 librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libssh2-1 libsz2 publicsuffix
0 upgraded, 21 newly installed, 0 to remove and 0 not upgraded. Need to get 4106 kB of archives.
After this operation, 12.2 MB of additional disk space will be used. Get:1 http://deb.debian.org/debian bullseye/main amd64 libbrotli1 amd64 1.0.9-2+b2 [279 kB] Get:2 http://deb.debian.org/debian bullseye/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg-2.1+deb11u1 [69.1 kB] Get:3 http://deb.debian.org/debian bullseye/main amd64 libsasl2-2 amd64 2.1.27+dfsg-2.1+deb11u1 [106 kB] Get:4 http://deb.debian.org/debian bullseye/main amd64 libldap-2.4-2 amd64 2.4.57+dfsg-3+deb11u1 [232 kB] Get:5 http://deb.debian.org/debian bullseye/main amd64 libnghttp2-14 amd64 1.43.0-1 [77.1 kB] Get:6 http://deb.debian.org/debian bullseye/main amd64 libpsl5 amd64 0.21.0-1.2 [57.3 kB] Get:7 http://deb.debian.org/debian bullseye/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2+b2 [60.8 kB] Get:8 http://deb.debian.org/debian bullseye/main amd64 libssh2-1 amd64 1.9.0-2 [156 kB] Get:9 http://deb.debian.org/debian-security bullseye-security/main amd64 libcurl4 amd64 7.74.0-1.3+deb11u7 [346 kB] Get:10 http://deb.debian.org/debian-security bullseye-security/main amd64 curl amd64 7.74.0-1.3+deb11u7 [270 kB] Get:11 http://deb.debian.org/debian bullseye/main amd64 libaec0 amd64 1.0.4-1 [20.3 kB] Get:12 http://deb.debian.org/debian bullseye/main amd64 libsz2 amd64 1.0.4-1 [6760 B] Get:13 http://deb.debian.org/debian bullseye/main amd64 libhdf5-103-1 amd64 1.10.6+repack-4+deb11u1 [1189 kB] Get:14 http://deb.debian.org/debian bullseye/main amd64 libhdf5-hl-100 amd64 1.10.6+repack-4+deb11u1 [81.8 kB] Get:15 http://deb.debian.org/debian bullseye/main amd64 hdf5-tools amd64 1.10.6+repack-4+deb11u1 [444 kB] Get:16 http://deb.debian.org/debian bullseye/main amd64 libonig5 amd64 6.9.6-1.1 [185 kB] Get:17 http://deb.debian.org/debian bullseye/main amd64 libjq1 amd64 1.6-2.1 [135 kB] Get:18 http://deb.debian.org/debian bullseye/main amd64 jq amd64 1.6-2.1 [64.9 kB] Get:19 http://deb.debian.org/debian bullseye/main amd64 libldap-common all 2.4.57+dfsg-3+deb11u1 [95.8 kB] Get:20 http://deb.debian.org/debian bullseye/main amd64 libsasl2-modules amd64 2.1.27+dfsg-2.1+deb11u1 [104 kB] Get:21 http://deb.debian.org/debian bullseye/main amd64 publicsuffix all 20220811.1734-0+deb11u1 [127 kB] .
.
Successfully built bff4d2f479ca
Successfully tagged stars:latest

(base) xxx@Micheles-MacBook-Pro Stars % docker run -it --entrypoint bash stars root@bf14643d7b37:/app#
root@bf14643d7b37:/app#
root@bf14643d7b37:/app# which jq
/usr/bin/jq
root@bf14643d7b37:/app# which curl
/usr/bin/curl
root@bf14643d7b37:/app# jq --version
jq-1.6
root@bf14643d7b37:/app# curl --version
curl 7.74.0 (x86_64-pc-linux-gnu) libcurl/7.74.0 OpenSSL/1.1.1n zlib/1.2.11 brotli/1.0.9 libidn2/2.3.0 libpsl/0.21.0 (+libidn2/2.3.0) libssh2/1.9.0 nghttp2/1.43.0 librtmp/2.3 Release-Date: 2020-12-09
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp Features: alt-svc AsynchDNS brotli GSS-API HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets Commit:
6f7a727eb4bd8a3db317d0348ed245f31d1de8f4 [6f7a727]