### PR TITLE
Support for Copernicus Data Space OData API

### DIFF
--- a/src/Stars.Console.Tests/Utilities/TestConsole.cs
+++ b/src/Stars.Console.Tests/Utilities/TestConsole.cs
@@ -25,7 +25,7 @@ namespace Stars.Console.Tests
 
         public TextReader In => throw new NotImplementedException();
 
-        public bool IsInputRedirected => throw new NotImplementedException();
+        public bool IsInputRedirected => true;
 
         public bool IsOutputRedirected => true;
 

--- a/src/Stars.Data/Suppliers/DataHubSourceSupplier.cs
+++ b/src/Stars.Data/Suppliers/DataHubSourceSupplier.cs
@@ -20,6 +20,7 @@ using Terradue.Stars.Interface;
 using Terradue.Stars.Services.Plugins;
 using System.Threading;
 
+
 namespace Terradue.Stars.Data.Suppliers
 {
     public class DataHubSourceSupplier : OpenSearchableSupplier, ISupplier
@@ -50,9 +51,21 @@ namespace Terradue.Stars.Data.Suppliers
             var target_uri = serviceUrl;
             var target_creds = credentialsManager;
 
-
             if (target_creds == null)
                 logger.LogWarning("Credentials are not set, target sites' services requiring credentials for data access will fail!");
+
+
+            if (target_uri.Host == "catalogue.dataspace.copernicus.eu")
+            {
+                wrapper = new CopernicusOdataWrapper(
+                    target_creds.GetCredential(new Uri("https://identity.dataspace.copernicus.eu"), "Basic"),
+                    "https://catalogue.dataspace.copernicus.eu/odata/v1"
+                );
+            }
+            else if (target_uri.Host.EndsWith("copernicus.eu"))
+            {
+                wrapper = new DHuSWrapper(target_uri, target_creds);
+            }
 
 
             if (target_uri.Host == "catalogue.onda-dias.eu")
@@ -92,11 +105,6 @@ namespace Terradue.Stars.Data.Suppliers
             {
                 // usgsOpenSearchable
                 wrapper = new Terradue.OpenSearch.Usgs.UsgsDataWrapper(new Uri("https://m2m.cr.usgs.gov"), target_creds);
-            }
-
-            if (target_uri.Host.EndsWith("copernicus.eu"))
-            {
-                wrapper = new DHuSWrapper(target_uri, target_creds);
             }
 
             if (target_uri.Host.EndsWith("amazon.com"))
@@ -150,4 +158,5 @@ namespace Terradue.Stars.Data.Suppliers
         }
 
     }
+
 }

--- a/src/Stars.Data/Terradue.Stars.Data.csproj
+++ b/src/Stars.Data/Terradue.Stars.Data.csproj
@@ -30,7 +30,7 @@
         <PackageReference Include="Terradue.MetadataExtractor" Version="1.3.0" />
         <PackageReference Include="ProjNet" Version="2.0.0" />
         <PackageReference Include="MimeTypes" Version="2.0.2" />
-        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.24.4" />
+        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.25.1" />
         <PackageReference Include="Terradue.OpenSearch.Asf" Version="1.2.*" />
         <PackageReference Include="Terradue.OpenSearch.Usgs" Version="1.6.*" />
         <PackageReference Include="Terradue.OpenSearch.GeoJson" Version="1.4.5" />

--- a/src/Stars.Data/stars-data.json
+++ b/src/Stars.Data/stars-data.json
@@ -3,6 +3,10 @@
         "Terradue": {
             "Assembly": "Terradue.Stars.Data",
             "Suppliers": {
+                "CDS": {
+                    "Type": "Terradue.Stars.Data.Suppliers.DataHubSourceSupplier",
+                    "ServiceUrl": "https://catalogue.dataspace.copernicus.eu/odata/v1"
+                },
                 "ONDA": {
                     "Type": "Terradue.Stars.Data.Suppliers.DataHubSourceSupplier",
                     "ServiceUrl": "https://catalogue.onda-dias.eu/dias-catalogue"


### PR DESCRIPTION
This change enables download from Copernicus Data Space OData API (https://catalogue.dataspace.copernicus.eu/odata/v1).

The actual code that introduces this functionality is part of Terradue.OpenSearch.SciHub, and the main change in Stars is an update of the dependency to version 1.25.1 of that package. The change also includes an addition to the wrapper configuration (based on the service URL) and the default Stars configuration.

The new functionality requires an account created at [Copernicus Data Space](https://dataspace.copernicus.eu/) and can be used by creating a configuration with that new supplier:
```
{
  "Plugins": {
    "Terradue": {
      "Suppliers": {
        "CDS": {
          "Type": "Terradue.Stars.Data.Suppliers.DataHubSourceSupplier",
          "ServiceUrl": "https://catalogue.dataspace.copernicus.eu/odata/v1",
          "Priority": 3
        }
      }
    }
  },
  "Credentials": {
    "CDS": {
      "AuthType": "basic",
      "UriPrefix": "https://identity.dataspace.copernicus.eu",
      "Username": "<username-or-email>",
      "Password": "<password>"
    }
  }
}