### PR TITLE
Fix for Copernicus Data Space (OData API) downloads

### DIFF
--- a/src/Stars.Data/Terradue.Stars.Data.csproj
+++ b/src/Stars.Data/Terradue.Stars.Data.csproj
@@ -30,7 +30,7 @@
         <PackageReference Include="Terradue.MetadataExtractor" Version="1.3.0" />
         <PackageReference Include="ProjNet" Version="2.0.0" />
         <PackageReference Include="MimeTypes" Version="2.0.2" />
-        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.25.2" />
+        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.25.5" />
         <PackageReference Include="Terradue.OpenSearch.Asf" Version="1.2.*" />
         <PackageReference Include="Terradue.OpenSearch.Usgs" Version="1.6.*" />
         <PackageReference Include="Terradue.OpenSearch.GeoJson" Version="1.4.5" />

--- a/src/Stars.Services/AssetService.cs
+++ b/src/Stars.Services/AssetService.cs
@@ -91,7 +91,7 @@ namespace Terradue.Stars.Services
                     if ( deliveryQuotation.AssetsExceptions.ContainsKey(assetDeliveries.Key))
                     {
                         reason += " : " + deliveryQuotation.AssetsExceptions[assetDeliveries.Key].Message;
-                        report.AssetsExceptions[assetDeliveries.Key] = new AssetImportException(reason) f;
+                        report.AssetsExceptions[assetDeliveries.Key] = new AssetImportException(reason);
                     }
                     else
                     {

--- a/src/Stars.Services/AssetService.cs
+++ b/src/Stars.Services/AssetService.cs
@@ -91,8 +91,12 @@ namespace Terradue.Stars.Services
                     if ( deliveryQuotation.AssetsExceptions.ContainsKey(assetDeliveries.Key))
                     {
                         reason += " : " + deliveryQuotation.AssetsExceptions[assetDeliveries.Key].Message;
+                        report.AssetsExceptions[assetDeliveries.Key] = new AssetImportException(reason) f;
                     }
-                    report.AssetsExceptions.Add(assetDeliveries.Key, new AssetImportException(reason));
+                    else
+                    {
+                        report.AssetsExceptions.Add(assetDeliveries.Key, new AssetImportException(reason));
+                    }
                     continue;
                 }
                 IResource importedResource = null;


### PR DESCRIPTION
This change fixes the following:
* Download via Copernicus Data Space OData API now work again (via new version 1.25.5 of Terradue.OpenSearch.SciHub)
* Possible duplicate-key error with asset delivery exceptions