### PR TITLE
CBERS-4/4A raster band offset value

### DIFF
--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND13.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND13.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.4351
+          "scale": 1.4351,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND14.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND14.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.4351
+          "scale": 1.4351,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND15.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND15.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.3903
+          "scale": 1.3903,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND16.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_CBERS_4_AWFI_20201031_003_075_L2_BAND16.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.3903
+          "scale": 1.3903,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_CBERS_4_AWFI_20220731_111_063_L4_B_compose.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_CBERS_4_AWFI_20220731_111_063_L4_B_compose.json
@@ -149,16 +149,20 @@
       ],
       "raster:bands": [
         {
-          "scale": 0.235
+          "scale": 0.235,
+          "offset": 0.0
         },
         {
-          "scale": 0.267
+          "scale": 0.267,
+          "offset": 0.0
         },
         {
-          "scale": 0.218
+          "scale": 0.218,
+          "offset": 0.0
         },
         {
-          "scale": 0.189
+          "scale": 0.189,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_Call1086_AWFI_20221009_105_087_L4_BAND16151413_FIRST.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/AWFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_Call1086_AWFI_20221009_105_087_L4_BAND16151413_FIRST.json
@@ -149,16 +149,20 @@
       ],
       "raster:bands": [
         {
-          "scale": 0.189
+          "scale": 0.189,
+          "offset": 0.0
         },
         {
-          "scale": 0.218
+          "scale": 0.218,
+          "offset": 0.0
         },
         {
-          "scale": 0.267
+          "scale": 0.267,
+          "offset": 0.0
         },
         {
-          "scale": 0.235
+          "scale": 0.235,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND5.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND5.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.51123
+          "scale": 1.51123,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND6.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND6.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.5762
+          "scale": 1.5762,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND7.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND7.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.55192
+          "scale": 1.55192,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND8.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/MUX/MetadataExtractorsTests_CBERS_4_MUX_20201031_003_073_L2_BAND8.json
@@ -106,7 +106,8 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.1761
+          "scale": 1.1761,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND2.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND2.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -102,6 +103,11 @@
           "center_wavelength": 0.555,
           "full_width_half_max": 0.07,
           "solar_illumination": 1823.4
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND3.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND3.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -102,6 +103,11 @@
           "center_wavelength": 0.66,
           "full_width_half_max": 0.06,
           "solar_illumination": 1536.38
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND4.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN10M/MetadataExtractorsTests_CBERS_4_PAN10M_20190510_027_076_L2_BAND4.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -102,6 +103,11 @@
           "center_wavelength": 0.83,
           "full_width_half_max": 0.12,
           "solar_illumination": 981.91
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN5M/MetadataExtractorsTests_CBERS_4_PAN5M_20190510_027_076_L2_BAND1.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4/PAN5M/MetadataExtractorsTests_CBERS_4_PAN5M_20190510_027_076_L2_BAND1.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -102,6 +103,11 @@
           "center_wavelength": 0.7,
           "full_width_half_max": 0.38,
           "solar_illumination": 1259.85
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND13.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND13.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -109,6 +110,11 @@
           "full_width_half_max": 0.07,
           "solar_illumination": 1984.65
         }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
+        }
       ]
     },
     "band-13-right": {
@@ -127,6 +133,11 @@
           "center_wavelength": 0.485,
           "full_width_half_max": 0.07,
           "solar_illumination": 1984.65
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND14.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND14.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -109,6 +110,11 @@
           "full_width_half_max": 0.07,
           "solar_illumination": 1823.4
         }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
+        }
       ]
     },
     "band-14-right": {
@@ -127,6 +133,11 @@
           "center_wavelength": 0.555,
           "full_width_half_max": 0.07,
           "solar_illumination": 1823.4
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND15.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND15.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -109,6 +110,11 @@
           "full_width_half_max": 0.06,
           "solar_illumination": 1536.38
         }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
+        }
       ]
     },
     "band-15-right": {
@@ -127,6 +133,11 @@
           "center_wavelength": 0.66,
           "full_width_half_max": 0.06,
           "solar_illumination": 1536.38
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND16.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_CBERS_4A_WFI_20200801_221_156_L4_BAND16.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -109,6 +110,11 @@
           "full_width_half_max": 0.12,
           "solar_illumination": 981.91
         }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
+        }
       ]
     },
     "band-16-right": {
@@ -127,6 +133,11 @@
           "center_wavelength": 0.83,
           "full_width_half_max": 0.12,
           "solar_illumination": 981.91
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_CBERS_4A_WFI_20230214_109_060_L2_compose.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WFI/MetadataExtractorsTests_urn_ogc_def_EOP_INPE_CBERS_4A_WFI_20230214_109_060_L2_compose.json
@@ -149,16 +149,20 @@
       ],
       "raster:bands": [
         {
-          "scale": 1.4351
+          "scale": 1.4351,
+          "offset": 0.0
         },
         {
-          "scale": 1.4351
+          "scale": 1.4351,
+          "offset": 0.0
         },
         {
-          "scale": 1.6559
+          "scale": 1.6559,
+          "offset": 0.0
         },
         {
-          "scale": 1.6559
+          "scale": 1.6559,
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND0.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND0.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -101,6 +102,11 @@
           "center_wavelength": 0.675,
           "full_width_half_max": 0.45,
           "solar_illumination": 1258.38
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND1.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND1.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -101,6 +102,11 @@
           "center_wavelength": 0.485,
           "full_width_half_max": 0.07,
           "solar_illumination": 1984.65
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND2.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND2.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -101,6 +102,11 @@
           "center_wavelength": 0.555,
           "full_width_half_max": 0.07,
           "solar_illumination": 1823.4
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND3.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND3.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -101,6 +102,11 @@
           "center_wavelength": 0.66,
           "full_width_half_max": 0.06,
           "solar_illumination": 1536.38
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND4.json
+++ b/src/Stars.Data.Tests/Resources/INPE/CBERS-4A/WPM/MetadataExtractorsTests_CBERS_4A_WPM_20200730_209_139_L4_BAND4.json
@@ -3,6 +3,7 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
@@ -101,6 +102,11 @@
           "center_wavelength": 0.83,
           "full_width_half_max": 0.12,
           "solar_illumination": 981.91
+        }
+      ],
+      "raster:bands": [
+        {
+          "offset": 0.0
         }
       ]
     },

--- a/src/Stars.Data/Model/Metadata/Cbers/CbersMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Cbers/CbersMetadataExtractor.cs
@@ -819,16 +819,14 @@ namespace Terradue.Stars.Data.Model.Metadata.Cbers
             };
 
             RasterBand rasterBand = null;
-            if (scale != null)
+            // data type and bits per sample can't be reliably set (defaults from above may not always apply).
+            rasterBand = new RasterBand()
             {
-                // data type and bits per sample can't be reliably set (defaults from above may not always apply).
-                rasterBand = new RasterBand()
-                {
-                    //DataType = dataType,
-                    //BitsPerSample = bitsPerSample,
-                    Scale = scale
-                };
-            }
+                //DataType = dataType,
+                //BitsPerSample = bitsPerSample,
+                Scale = scale,
+                Offset = 0
+            };
 
             if (stacAsset == null)
             {


### PR DESCRIPTION
This change addes the `raster:bands` `offset` value (always 0) for STAC items of CBERS-4 and CBERS-4A products.