### PR TITLE
ESACPE-1597 Pleiades NEO band order fix

### DIFF
--- a/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
+++ b/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
@@ -101,12 +101,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -117,12 +117,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -133,7 +133,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -153,7 +153,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],
@@ -185,12 +185,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -201,12 +201,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -217,7 +217,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -237,7 +237,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],
@@ -269,12 +269,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -285,12 +285,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -301,7 +301,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -321,7 +321,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],
@@ -353,12 +353,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -369,12 +369,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -385,7 +385,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -405,7 +405,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],
@@ -437,12 +437,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -453,12 +453,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -469,7 +469,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -489,7 +489,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],
@@ -521,12 +521,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB-B3 Blue",
+          "name": "RGB-B1 Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB-B2 Green",
@@ -537,12 +537,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB-B1 Red",
+          "name": "RGB-B3 Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         }
       ],
       "raster:bands": [
@@ -553,7 +553,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.1531628120692296,
+          "scale": 0.12547051442910917,
           "offset": 0.0
         },
         {
@@ -573,7 +573,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12547051442910917,
+          "scale": 0.1531628120692296,
           "offset": 0.0
         }
       ],

--- a/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20230726072204_PMS_ORTHO_PWOI_000115104_1_1_F_1_STD.json
+++ b/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20230726072204_PMS_ORTHO_PWOI_000115104_1_1_F_1_STD.json
@@ -101,12 +101,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "RGB Blue",
+          "name": "RGB Red",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "blue",
-          "center_wavelength": 0.483,
-          "solar_illumination": 1972.0,
-          "full_width_half_max": 0.074
+          "common_name": "red",
+          "center_wavelength": 0.6545,
+          "solar_illumination": 1551.7,
+          "full_width_half_max": 0.071
         },
         {
           "name": "RGB Green",
@@ -117,12 +117,12 @@
           "full_width_half_max": 0.058
         },
         {
-          "name": "RGB Red",
+          "name": "RGB Blue",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "red",
-          "center_wavelength": 0.6545,
-          "solar_illumination": 1551.7,
-          "full_width_half_max": 0.071
+          "common_name": "blue",
+          "center_wavelength": 0.483,
+          "solar_illumination": 1972.0,
+          "full_width_half_max": 0.074
         },
         {
           "name": "RGB Nir",
@@ -141,7 +141,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.15121729925903524,
+          "scale": 0.12470382840753211,
           "offset": 0.0
         },
         {
@@ -161,7 +161,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.12470382840753211,
+          "scale": 0.15121729925903524,
           "offset": 0.0
         },
         {

--- a/src/Stars.Data/Model/Metadata/Airbus/PleiadesNEODimapProfiler.cs
+++ b/src/Stars.Data/Model/Metadata/Airbus/PleiadesNEODimapProfiler.cs
@@ -30,15 +30,23 @@ namespace Terradue.Stars.Data.Model.Metadata.Airbus
         protected override IDictionary<EoBandCommonName?, int> BandOrders
         {
             get
-            {   //MS-FS assets
+            {
                 Dictionary<EoBandCommonName?, int> bandOrders = new Dictionary<EoBandCommonName?, int>();
-                bandOrders.Add(EoBandCommonName.blue, 0);
-                bandOrders.Add(EoBandCommonName.green, 1);
-                bandOrders.Add(EoBandCommonName.red, 2);
-                bandOrders.Add(EoBandCommonName.coastal, 3);
-                bandOrders.Add(EoBandCommonName.rededge, 4);
-                bandOrders.Add(EoBandCommonName.nir, 5);
-                bandOrders.Add(EoBandCommonName.pan, 6);
+                if (Dimap.Processing_Information.Product_Settings.SPECTRAL_PROCESSING == "PMS-X") {
+                    bandOrders.Add(EoBandCommonName.green, 0);
+                    bandOrders.Add(EoBandCommonName.red, 1);
+                    bandOrders.Add(EoBandCommonName.nir, 2);
+                }
+                else {
+                    bandOrders.Add(EoBandCommonName.red, 0);
+                    bandOrders.Add(EoBandCommonName.green, 1);
+                    bandOrders.Add(EoBandCommonName.blue, 2);
+                    bandOrders.Add(EoBandCommonName.coastal, 3);
+                    bandOrders.Add(EoBandCommonName.rededge, 4);
+                    bandOrders.Add(EoBandCommonName.nir, 5);
+                    bandOrders.Add(EoBandCommonName.pan, 6);
+                }
+
                 return bandOrders;
             }
         }


### PR DESCRIPTION
## Changes:

- Resolved the issue with the order of band and raster bands in Pleiades NEO Stac items.
- The new order now aligns with spectral processing values (eg PMS-X and non PMS-X)
- Updated unit test cases to ensure proper validation