### PR TITLE
ESACPE-1694 Pleiades NEO order fix

### DIFF
--- a/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
+++ b/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
@@ -605,12 +605,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -621,12 +621,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -637,7 +637,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -657,7 +657,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],
@@ -689,12 +689,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -705,12 +705,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -721,7 +721,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -741,7 +741,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],
@@ -773,12 +773,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -789,12 +789,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -805,7 +805,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -825,7 +825,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],
@@ -857,12 +857,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -873,12 +873,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -889,7 +889,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -909,7 +909,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],
@@ -941,12 +941,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -957,12 +957,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -973,7 +973,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -993,7 +993,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],
@@ -1025,12 +1025,12 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "NED-B3 Coastal",
+          "name": "NED-B1 Nir",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "coastal",
-          "center_wavelength": 0.4365,
-          "solar_illumination": 1797.1,
-          "full_width_half_max": 0.041
+          "common_name": "nir",
+          "center_wavelength": 0.828,
+          "solar_illumination": 1060.1,
+          "full_width_half_max": 0.12
         },
         {
           "name": "NED-B2 Rededge",
@@ -1041,12 +1041,12 @@
           "full_width_half_max": 0.053
         },
         {
-          "name": "NED-B1 Nir",
+          "name": "NED-B3 Coastal",
           "description": "Raw radiometric count (DN) to TOA Radiance (L). Formulae L=DN/GAIN+BIAS",
-          "common_name": "nir",
-          "center_wavelength": 0.828,
-          "solar_illumination": 1060.1,
-          "full_width_half_max": 0.12
+          "common_name": "coastal",
+          "center_wavelength": 0.4365,
+          "solar_illumination": 1797.1,
+          "full_width_half_max": 0.041
         }
       ],
       "raster:bands": [
@@ -1057,7 +1057,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.11668611435239207,
+          "scale": 0.08476012883539583,
           "offset": 0.0
         },
         {
@@ -1077,7 +1077,7 @@
             "minimum": 0.0,
             "maximum": 4096.0
           },
-          "scale": 0.08476012883539583,
+          "scale": 0.11668611435239207,
           "offset": 0.0
         }
       ],

--- a/src/Stars.Data/Model/Metadata/Airbus/PleiadesNEODimapProfiler.cs
+++ b/src/Stars.Data/Model/Metadata/Airbus/PleiadesNEODimapProfiler.cs
@@ -41,9 +41,9 @@ namespace Terradue.Stars.Data.Model.Metadata.Airbus
                     bandOrders.Add(EoBandCommonName.red, 0);
                     bandOrders.Add(EoBandCommonName.green, 1);
                     bandOrders.Add(EoBandCommonName.blue, 2);
-                    bandOrders.Add(EoBandCommonName.coastal, 3);
+                    bandOrders.Add(EoBandCommonName.nir, 3);
                     bandOrders.Add(EoBandCommonName.rededge, 4);
-                    bandOrders.Add(EoBandCommonName.nir, 5);
+                    bandOrders.Add(EoBandCommonName.coastal, 5);
                     bandOrders.Add(EoBandCommonName.pan, 6);
                 }
 


### PR DESCRIPTION
Nir and Coastal bands have to be inverted in the order.