### PR TITLE
ESACPE-1695 PNEO: include all spectral processings in the title

### DIFF
--- a/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
+++ b/src/Stars.Data.Tests/Resources/AIRBUS/PLEIADES-NEO/ORT/MetadataExtractorsTests_PNEO4_20211115135830_PMS_ORTHO_PWOI_000071864_1_1_F_1_STD.json
@@ -48,7 +48,7 @@
     ],
     "sensor_type": "optical",
     "gsd": 1.34,
-    "title": "PNEO4 MS-FS ORTHO 2021-11-15 13:58:30",
+    "title": "PNEO4 PAN MS-FS ORTHO 2021-11-15 13:58:30",
     "sat:platform_international_designator": "2021-073E",
     "proj:epsg": 32622,
     "proj:shape": [


### PR DESCRIPTION
 PNEO stac item title must include all spectral processings in the title.
eg. PAN and MS-FS:
```
PNEO4 MS-FS PAN ORTHO 2021-11-15 13:58:30
```

note: PAN should be listed first