### PR TITLE
Fix for cloud coverage filter on Copernicus Data Space OData

### DIFF
--- a/src/Stars.Data/Terradue.Stars.Data.csproj
+++ b/src/Stars.Data/Terradue.Stars.Data.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="Terradue.MetadataExtractor" Version="1.3.0" />
         <PackageReference Include="ProjNet" Version="2.0.0" />
         <PackageReference Include="MimeTypes" Version="2.0.2" />
-        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.25.6" />
+        <PackageReference Include="Terradue.OpenSearch.SciHub" Version="1.28.*" />
         <PackageReference Include="Terradue.OpenSearch.Asf" Version="1.2.*" />
         <PackageReference Include="Terradue.OpenSearch.Usgs" Version="1.6.*" />
         <PackageReference Include="Terradue.OpenSearch.GeoJson" Version="1.4.5" />


### PR DESCRIPTION
With this change, filtering by cloud coverage for Sentinel-2 data works with Copernicus Data Space OData API.
The change is in the dependency Terradue.OpenSearch.SciHub, which was updated.

Cloud coverage filter values can be in different forms:
* simple number (assumed to be the maximum desired value)
* interval syntax (e.g. `[10`, `10]`, `[10,20[`, `[10,20)`, `[10,20]`, with these types of parenthesis to designate open or closed intervals: `[]()`