### PR TITLE
Improved SAOCOM-1 metadata extraction

### DIFF
--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1A/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1A/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240.json
@@ -109,7 +109,6 @@
       ],
       "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml",
-      "file:size": 45186
     },
     "amplitude-hh": {
       "type": "image/tiff; application=geotiff",
@@ -119,7 +118,6 @@
       ],
       "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh",
-      "file:size": 0,
       "sar:polarizations": [
         "HH"
       ]
@@ -131,7 +129,6 @@
       ],
       "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml",
-      "file:size": 45188
     },
     "amplitude-hv": {
       "type": "image/tiff; application=geotiff",
@@ -141,7 +138,6 @@
       ],
       "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv",
-      "file:size": 0,
       "sar:polarizations": [
         "HV"
       ]

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1A/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1A/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240.json
@@ -38,6 +38,8 @@
   },
   "properties": {
     "sat:orbit_state": "ascending",
+    "saocom:path": 149,
+    "saocom:row": 447,
     "proj:epsg": null,
     "proj:shape": [
       6419,
@@ -105,8 +107,9 @@
       "roles": [
         "metadata"
       ],
-      "href": "S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml",
-      "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml"
+      "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml",
+      "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh.xml",
+      "file:size": 45186
     },
     "amplitude-hh": {
       "type": "image/tiff; application=geotiff",
@@ -114,8 +117,9 @@
         "amplitude",
         "data"
       ],
-      "href": "S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh",
+      "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hh",
+      "file:size": 0,
       "sar:polarizations": [
         "HH"
       ]
@@ -125,8 +129,9 @@
       "roles": [
         "metadata"
       ],
-      "href": "S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml",
-      "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml"
+      "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml",
+      "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv.xml",
+      "file:size": 45188
     },
     "amplitude-hv": {
       "type": "image/tiff; application=geotiff",
@@ -134,8 +139,9 @@
         "amplitude",
         "data"
       ],
-      "href": "S1A_OPER_SAR_EOSSP__CORE_L1A_OLF_20211117T174240/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv",
+      "href": "data/286806-EOL1ASARSAO1A3111864/Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv",
       "filename": "Data/slc-acqId0000588416-a-sm5-2111181029-s5dp-hv",
+      "file:size": 0,
       "sar:polarizations": [
         "HV"
       ]

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1C/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1C_OLF_20200304T225242.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1C/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1C_OLF_20200304T225242.json
@@ -38,6 +38,8 @@
   },
   "properties": {
     "sat:orbit_state": "descending",
+    "saocom:path": 34,
+    "saocom:row": 151,
     "proj:epsg": null,
     "proj:shape": [
       4463,

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1C/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1C_OLF_20200304T225242.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1C/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1C_OLF_20200304T225242.json
@@ -37,16 +37,6 @@
     ]
   },
   "properties": {
-    "datetime": "2019-11-08T09:50:27.048Z",
-    "created": "2020-03-04T23:12:48Z",
-    "platform": "saocom-1a",
-    "mission": "saocom-1",
-    "instruments": [
-      "sao1a"
-    ],
-    "sensor_type": "radar",
-    "gsd": 10.0,
-    "title": "SAOCOM-1A SAO1A GEC VV/VH/HH/HV 2019-11-08 09:50:27",
     "sat:orbit_state": "descending",
     "proj:epsg": null,
     "proj:shape": [
@@ -71,6 +61,16 @@
     "sar:resolution_range": 10.0,
     "sar:resolution_azimuth": 10.0,
     "processing:level": "L1C",
+    "datetime": "2019-11-08T09:50:27.048Z",
+    "created": "2020-03-04T23:12:48Z",
+    "platform": "saocom-1a",
+    "mission": "saocom-1",
+    "instruments": [
+      "sao1a"
+    ],
+    "sensor_type": "radar",
+    "gsd": 10.0,
+    "title": "SAOCOM-1A SAO1A GEC VV/VH/HH/HV 2019-11-08 09:50:27",
     "providers": [
       {
         "name": "CONAE",

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20200819T231514.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20200819T231514.json
@@ -38,6 +38,8 @@
   },
   "properties": {
     "sat:orbit_state": "ascending",
+    "saocom:row": 529,
+    "saocom:path": 137,
     "proj:epsg": null,
     "proj:shape": [
       9848,

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20200819T231514.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20200819T231514.json
@@ -37,15 +37,6 @@
     ]
   },
   "properties": {
-    "datetime": "2020-08-19T21:17:26.613Z",
-    "created": "2020-08-20T01:29:31Z",
-    "platform": "saocom-1a",
-    "mission": "saocom-1",
-    "instruments": [
-      "sao1a"
-    ],
-    "sensor_type": "radar",
-    "title": "SAOCOM-1A SAO1A GTC VV/VH 2020-08-19 21:17:26",
     "sat:orbit_state": "ascending",
     "proj:epsg": null,
     "proj:shape": [
@@ -68,6 +59,15 @@
     "sar:resolution_range": 50.0,
     "sar:resolution_azimuth": 50.0,
     "processing:level": "L1D",
+    "datetime": "2020-08-19T21:17:26.613Z",
+    "created": "2020-08-20T01:29:31Z",
+    "platform": "saocom-1a",
+    "mission": "saocom-1",
+    "instruments": [
+      "sao1a"
+    ],
+    "sensor_type": "radar",
+    "title": "SAOCOM-1A SAO1A GTC VV/VH 2020-08-19 21:17:26",
     "providers": [
       {
         "name": "CONAE",

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20210204T093006.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20210204T093006.json
@@ -38,6 +38,8 @@
   },
   "properties": {
     "sat:orbit_state": "ascending",
+    "saocom:row": 406,
+    "saocom:path": 209,
     "proj:epsg": null,
     "proj:shape": [
       4817,

--- a/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20210204T093006.json
+++ b/src/Stars.Data.Tests/Resources/CONAE/SAOCOM-1/L1D/MetadataExtractorsTests_S1A_OPER_SAR_EOSSP__CORE_L1D_OLVF_20210204T093006.json
@@ -37,15 +37,6 @@
     ]
   },
   "properties": {
-    "datetime": "2021-02-04T04:14:38.399Z",
-    "created": "2021-02-04T10:43:10Z",
-    "platform": "saocom-1a",
-    "mission": "saocom-1",
-    "instruments": [
-      "sao1a"
-    ],
-    "sensor_type": "radar",
-    "title": "SAOCOM-1A SAO1A GTC VV/VH/HH/HV 2021-02-04 04:14:38",
     "sat:orbit_state": "ascending",
     "proj:epsg": null,
     "proj:shape": [
@@ -70,6 +61,15 @@
     "sar:resolution_range": 50.0,
     "sar:resolution_azimuth": 50.0,
     "processing:level": "L1D",
+    "datetime": "2021-02-04T04:14:38.399Z",
+    "created": "2021-02-04T10:43:10Z",
+    "platform": "saocom-1a",
+    "mission": "saocom-1",
+    "instruments": [
+      "sao1a"
+    ],
+    "sensor_type": "radar",
+    "title": "SAOCOM-1A SAO1A GTC VV/VH/HH/HV 2021-02-04 04:14:38",
     "providers": [
       {
         "name": "CONAE",

--- a/src/Stars.Data/Model/Metadata/Saocom1/Schema.cs
+++ b/src/Stars.Data/Model/Metadata/Saocom1/Schema.cs
@@ -360,7 +360,9 @@ namespace Terradue.Stars.Data.Model.Metadata.Saocom1
         public string At { get; set; }
     }
 
-    // XEMT files (incomplete classes)
+    // =========================================================================
+    // .xemt files (incomplete classes)
+    // =========================================================================
 
     [XmlRoot(ElementName = "xemt", Namespace = "http://www.conae.gov.ar/CUSS/XEMT")]
     public class XEMT
@@ -473,5 +475,44 @@ namespace Terradue.Stars.Data.Model.Metadata.Saocom1
         [XmlElement(ElementName = "Row")]
         public int Row { get; set; }
     }
+
+    // =========================================================================
+    // parameters2.xml
+    // =========================================================================
+
+    [XmlRoot(ElementName = "parameters", Namespace = "http://www.conae.gov.ar/CGSS/XPNet")]
+    public class ParameterFile
+    {
+        [XmlElement(ElementName = "inputs")]
+        public Inputs Inputs { get; set; }
+        [XmlElement(ElementName = "outputs")]
+        public Outputs Outputs { get; set; }
+    }
+
+    [XmlRoot(ElementName = "inputs")]
+    public class Inputs
+    {
+        [XmlElement(ElementName = "parameter")]
+        public List<Parameter> Parameters { get; set; }
+    }
+
+    [XmlRoot(ElementName = "outputs")]
+    public class Outputs
+    {
+        [XmlElement(ElementName = "parameter")]
+        public List<Parameter> Parameters { get; set; }
+    }
+
+    [XmlRoot(ElementName = "parameter")]
+    public class Parameter
+    {
+        [XmlElement(ElementName = "name")]
+        public string Name { get; set; }
+        [XmlElement(ElementName = "type")]
+        public string Type { get; set; }
+        [XmlElement(ElementName = "value")]
+        public string Value { get; set; }
+    }
+
 
 }

--- a/src/Stars.Data/Model/Metadata/Saocom1/Schema.cs
+++ b/src/Stars.Data/Model/Metadata/Saocom1/Schema.cs
@@ -410,6 +410,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Saocom1
         public Production Production { get; set; }
         [XmlElement(ElementName = "acquisition")]
         public Acquisition Acquisition { get; set; }
+        [XmlElement(ElementName = "geographicAttributes")]
+        public GeographicAttributes GeographicAttributes { get; set; }
 
     }
 
@@ -456,5 +458,20 @@ namespace Terradue.Stars.Data.Model.Metadata.Saocom1
         public string SideLooking { get; set; }
     }
 
+    [XmlRoot(ElementName = "geographicAttributes")]
+    public class GeographicAttributes
+    {
+        [XmlElement(ElementName = "pathRow")]
+        public PathRow PathRow { get; set; }
+    }
+
+    [XmlRoot(ElementName = "pathRow")]
+    public class PathRow
+    {
+        [XmlElement(ElementName = "Path")]
+        public int Path { get; set; }
+        [XmlElement(ElementName = "Row")]
+        public int Row { get; set; }
+    }
 
 }

--- a/src/Stars.Services/Processing/ZipArchiveAsset.cs
+++ b/src/Stars.Services/Processing/ZipArchiveAsset.cs
@@ -98,6 +98,9 @@ namespace Terradue.Stars.Services.Processing
             }
         }
 
+        public bool IsInternalArchive { get; set; }
+
+
         // Directory where ZIP file is located
         // (value is set automatically if UseParentAssetBaseDir is set to true)
         public string ParentAssetBaseDir { get; set; }
@@ -119,7 +122,7 @@ namespace Terradue.Stars.Services.Processing
         {
             Dictionary<string, IAsset> assetsExtracted = new Dictionary<string, IAsset>();
             zipFile = Ionic.Zip.ZipFile.Read(await GetZipStreamAsync(asset, carrierManager, ct));
-            string subFolder = AutodetectSubfolder();
+            string subFolder = IsInternalArchive ? String.Empty : AutodetectSubfolder();
 
             foreach (var archiveAsset in Assets)
             {


### PR DESCRIPTION
This change improves the metadata extraction for SAOCOM-1 products:
*  The content of nested ZIP archives is extracted in the correct place (in the same directory where the archive itself is located)
* Orbit substitute information (path and row) is extract from XEMT metadata file or (in absence of XEMT) from the metadata file containing the parameters (`parameterFile2.txt`).