### PR TITLE
Fix for Kanopus-V band order

### DIFF
--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/IK/MetadataExtractorsTests_KVIK_19382_19377_02_3NP2_07_ORT.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/IK/MetadataExtractorsTests_KVIK_19382_19377_02_3NP2_07_ORT.json
@@ -272,9 +272,9 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -282,9 +282,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/KVIK/MetadataExtractorsTests_KVIK_24382_24381_01_3NP2_20_ORT.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/KVIK/MetadataExtractorsTests_KVIK_24382_24381_01_3NP2_20_ORT.json
@@ -264,9 +264,9 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -274,9 +274,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/KVIK/MetadataExtractorsTests_fr_KVIK_28474_28472_02_3NP2_83.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/KVIK/MetadataExtractorsTests_fr_KVIK_28474_28472_02_3NP2_83.json
@@ -108,9 +108,9 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -118,9 +118,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V3/MetadataExtractorsTests_KV3_16300_16298_01_3NP2_20_ORT.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V3/MetadataExtractorsTests_KV3_16300_16298_01_3NP2_20_ORT.json
@@ -160,9 +160,9 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -170,9 +170,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V3/MetadataExtractorsTests_KV3_21226_21226_01_3NP2_83_ORT.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V3/MetadataExtractorsTests_KV3_21226_21226_01_3NP2_83_ORT.json
@@ -1144,9 +1144,9 @@
       "file:size": 0,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -1154,9 +1154,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V5/MetadataExtractorsTests_KV5_15173_15173_01_3NP2_08_ORT.json
+++ b/src/Stars.Data.Tests/Resources/ROSCOSMOS/KANOPUS-V/V5/MetadataExtractorsTests_KV5_15173_15173_01_3NP2_08_ORT.json
@@ -392,9 +392,9 @@
       "file:size": 1,
       "eo:bands": [
         {
-          "name": "blue",
-          "common_name": "blue",
-          "description": "blue"
+          "name": "red",
+          "common_name": "red",
+          "description": "red"
         },
         {
           "name": "green",
@@ -402,9 +402,9 @@
           "description": "green"
         },
         {
-          "name": "red",
-          "common_name": "red",
-          "description": "red"
+          "name": "blue",
+          "common_name": "blue",
+          "description": "blue"
         },
         {
           "name": "nir",

--- a/src/Stars.Data/Model/Metadata/Kanopus/KanopusVMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Kanopus/KanopusVMetadataExtractor.cs
@@ -236,9 +236,14 @@ namespace Terradue.Stars.Data.Model.Metadata.Kanopus
                         eoarr[i] = new EoBandObject("nir", EoBandCommonName.nir);
                         eoarr[i].Properties.Add("description", "nir");
                     }
+
+                }
+                // Swap bands 1 and 3 (red and blue) if the channels are not in RGB order in the metadata
+                if (numberOfChannels >= 3 && eoarr[0].CommonName == EoBandCommonName.blue && eoarr[2].CommonName == EoBandCommonName.red)
+                {
+                    (eoarr[2], eoarr[0]) = (eoarr[0], eoarr[2]);
                 }
                 stacAsset.EoExtension().Bands = eoarr;
-
             }
             else if (name == "PAN")
             {


### PR DESCRIPTION
With this change, the metadata extractor for Kanopus-V corrects the band order for RGB(N) assets so that the order is always RGB(N) as this is the band order in the image file regardless of what the metadata XML states.