### PR TITLE
tryAdd additional handlings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bullseye-slim-amd64
 
 RUN apt-get update -qy \
   && apt-get upgrade -y \
-  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl vi \
+  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl vim \
   && rm -rf /var/lib/apt/lists/* /tmp/*
   
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN dotnet publish -c release -o /app -r linux-x64 -f net6.0 --self-contained tr
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bullseye-slim-amd64
 
-RUN apt-get update \
+RUN apt-get update -qy \
   && apt-get upgrade -y \
-  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl \
+  && apt-get install -y hdf5-tools libssl1.1 libgssapi-krb5-2 ca-certificates jq curl vi \
   && rm -rf /var/lib/apt/lists/* /tmp/*
   
 WORKDIR /app

--- a/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
@@ -209,17 +209,17 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (filename.EndsWith("-MSS1_thumb.jpg", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2_thumb.jpg", true, CultureInfo.InvariantCulture)
                ) {
-                if (stacItem.Assets.TryAdd("MSS-thumbnail",
-                    GetGenericAsset(stacItem, asset.Uri, "thumbnail")))
-                stacItem.Assets["MSS-thumbnail"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-thumbnail", GetGenericAsset(stacItem, asset.Uri, "thumbnail"))) {
+                    stacItem.Assets["MSS-thumbnail"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             if (filename.EndsWith("-PAN1_thumb.jpg", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-PAN2_thumb.jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("PAN-thumbnail",
-                    GetGenericAsset(stacItem, asset.Uri, "thumbnail")))
-                stacItem.Assets["PAN-thumbnail"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("PAN-thumbnail", GetGenericAsset(stacItem, asset.Uri, "thumbnail"))) {
+                    stacItem.Assets["PAN-thumbnail"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
@@ -228,26 +228,26 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith("thumb.jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("MSS-thumbnail",
-                    GetGenericAsset(stacItem, asset.Uri, "thumbnail")))
-                stacItem.Assets["MSS-thumbnail"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-thumbnail", GetGenericAsset(stacItem, asset.Uri, "thumbnail"))) {
+                    stacItem.Assets["MSS-thumbnail"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith("thumb.jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd($"{type}-thumbnail",
-                    GetGenericAsset(stacItem, asset.Uri, "thumbnail")))
-                stacItem.Assets[$"{type}-thumbnail"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd($"{type}-thumbnail", GetGenericAsset(stacItem, asset.Uri, "thumbnail"))) {
+                    stacItem.Assets[$"{type}-thumbnail"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             // overview
             if (filename.EndsWith("-MSS1.jpg", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2.jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("MSS-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview"))) 
-                stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-overview", GetGenericAsset(stacItem, asset.Uri, "overview")))  {
+                    stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
@@ -263,33 +263,32 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("MSS-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview")))
-                stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-overview", GetGenericAsset(stacItem, asset.Uri, "overview"))) {
+                    stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".jpg", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd($"{type}-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview")))
-                stacItem.Assets[$"{type}-overview"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd($"{type}-overview", GetGenericAsset(stacItem, asset.Uri, "overview"))) {
+                    stacItem.Assets[$"{type}-overview"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             // metadata
             if (filename.EndsWith("-MSS1.xml", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2.xml", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("MSS-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
-                stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-metadata", GetGenericAsset(stacItem, asset.Uri, "metadata"))) {
+                    stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
-            if (filename.EndsWith("-PAN1.xml", true, CultureInfo.InvariantCulture) ||
-                filename.EndsWith("-PAN2.xml", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("PAN-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+            if (filename.EndsWith("-PAN1.xml", true, CultureInfo.InvariantCulture) 
+                || filename.EndsWith("-PAN2.xml", true, CultureInfo.InvariantCulture)) {
+                stacItem.Assets.Add("PAN-metadata", GetGenericAsset(stacItem, asset.Uri, "metadata"));
                 stacItem.Assets["PAN-metadata"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -297,33 +296,31 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".xml", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd("MSS-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
-                stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd("MSS-metadata", GetGenericAsset(stacItem, asset.Uri, "metadata"))) {
+                    stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".xml", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd($"{type}-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
-                stacItem.Assets[$"{type}-metadata"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd($"{type}-metadata", GetGenericAsset(stacItem, asset.Uri, "metadata"))) {
+                    stacItem.Assets[$"{type}-metadata"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
             // rpb metadata
             if (filename.EndsWith("-MSS1.rpb", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2.rpb", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("MSS-rpb",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                stacItem.Assets.Add("MSS-rpb", GetGenericAsset(stacItem, asset.Uri, "metadata"));
                 stacItem.Assets["MSS-rpb"].Properties.AddRange(asset.Properties);
                 return;
             }
 
             if (filename.EndsWith("-PAN1.rpb", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-PAN2.rpb", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("PAN-rpb",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                stacItem.Assets.Add("PAN-rpb", GetGenericAsset(stacItem, asset.Uri, "metadata"));
                 stacItem.Assets["PAN-rpb"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -331,17 +328,16 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".rpb", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("MSS-rpb",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                stacItem.Assets.Add("MSS-rpb", GetGenericAsset(stacItem, asset.Uri, "metadata"));
                 stacItem.Assets["MSS-rpb"].Properties.AddRange(asset.Properties);
                 return;
             }
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".rpb", true, CultureInfo.InvariantCulture)) {
-                if (stacItem.Assets.TryAdd($"{type}-rpb",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
-                stacItem.Assets[$"{type}-rpb"].Properties.AddRange(asset.Properties);
+                if (stacItem.Assets.TryAdd($"{type}-rpb", GetGenericAsset(stacItem, asset.Uri, "metadata"))) {
+                    stacItem.Assets[$"{type}-rpb"].Properties.AddRange(asset.Properties);
+                }
                 return;
             }
 
@@ -800,8 +796,7 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
         private void AddOtherProperties(ProductMetaData productMetadata, StacItem stacItem) {
             stacItem.Properties.Add("product_type", "PAN_MS_" + productMetadata.ProductLevel.Replace("LEVEL", "L"));
-            if (IncludeProviderProperty)
-            {
+            if (IncludeProviderProperty) {
                 AddSingleProvider(
                     stacItem.Properties,
                     "CNSA", 

--- a/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
@@ -280,8 +280,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             // metadata
             if (filename.EndsWith("-MSS1.xml", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2.xml", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("MSS-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                if (stacItem.Assets.TryAdd("MSS-metadata",
+                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -297,8 +297,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".xml", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.Add("MSS-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                if (stacItem.Assets.TryAdd("MSS-metadata",
+                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets["MSS-metadata"].Properties.AddRange(asset.Properties);
                 return;
             }

--- a/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
@@ -245,8 +245,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             // overview
             if (filename.EndsWith("-MSS1.jpg", true, CultureInfo.InvariantCulture) ||
                 filename.EndsWith("-MSS2.jpg", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.TryAdd("MSS-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview"));
+                if (stacItem.Assets.TryAdd("MSS-overview",
+                    GetGenericAsset(stacItem, asset.Uri, "overview"))) 
                 stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -263,16 +263,16 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
             if (satelliteImagery == null &&
                 filename.StartsWith("GF1", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".jpg", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.TryAdd("MSS-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview"));
+                if (stacItem.Assets.TryAdd("MSS-overview",
+                    GetGenericAsset(stacItem, asset.Uri, "overview")))
                 stacItem.Assets["MSS-overview"].Properties.AddRange(asset.Properties);
                 return;
             }
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".jpg", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.TryAdd($"{type}-overview",
-                    GetGenericAsset(stacItem, asset.Uri, "overview"));
+                if(stacItem.Assets.TryAdd($"{type}-overview",
+                    GetGenericAsset(stacItem, asset.Uri, "overview")))
                 stacItem.Assets[$"{type}-overview"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -305,8 +305,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".xml", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.TryAdd($"{type}-metadata",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                if(stacItem.Assets.TryAdd($"{type}-metadata",
+                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets[$"{type}-metadata"].Properties.AddRange(asset.Properties);
                 return;
             }
@@ -339,8 +339,8 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".rpb", true, CultureInfo.InvariantCulture)) {
-                stacItem.Assets.TryAdd($"{type}-rpb",
-                    GetGenericAsset(stacItem, asset.Uri, "metadata"));
+                if(stacItem.Assets.TryAdd($"{type}-rpb",
+                    GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets[$"{type}-rpb"].Properties.AddRange(asset.Properties);
                 return;
             }

--- a/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs
@@ -116,7 +116,7 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
         private void AddProjStacExtension(ProductMetaData productMetaData, StacItem stacItem) {
             ProjectionStacExtension proj = stacItem.ProjectionExtension();
-            if(!string.IsNullOrEmpty(productMetaData.MapProjection) && productMetaData.MapProjection == "WGS84"){
+            if (!string.IsNullOrEmpty(productMetaData.MapProjection) && productMetaData.MapProjection == "WGS84") {
                 proj.SetCoordinateSystem(ProjNet.CoordinateSystems.GeocentricCoordinateSystem.WGS84);
             }
             else {
@@ -271,7 +271,7 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".jpg", true, CultureInfo.InvariantCulture)) {
-                if(stacItem.Assets.TryAdd($"{type}-overview",
+                if (stacItem.Assets.TryAdd($"{type}-overview",
                     GetGenericAsset(stacItem, asset.Uri, "overview")))
                 stacItem.Assets[$"{type}-overview"].Properties.AddRange(asset.Properties);
                 return;
@@ -305,7 +305,7 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".xml", true, CultureInfo.InvariantCulture)) {
-                if(stacItem.Assets.TryAdd($"{type}-metadata",
+                if (stacItem.Assets.TryAdd($"{type}-metadata",
                     GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets[$"{type}-metadata"].Properties.AddRange(asset.Properties);
                 return;
@@ -339,7 +339,7 @@ namespace Terradue.Stars.Data.Model.Metadata.Gaofen {
 
             if (filename.StartsWith("GF4", true, CultureInfo.InvariantCulture) &&
                 filename.EndsWith(".rpb", true, CultureInfo.InvariantCulture)) {
-                if(stacItem.Assets.TryAdd($"{type}-rpb",
+                if (stacItem.Assets.TryAdd($"{type}-rpb",
                     GetGenericAsset(stacItem, asset.Uri, "metadata")))
                 stacItem.Assets[$"{type}-rpb"].Properties.AddRange(asset.Properties);
                 return;


### PR DESCRIPTION
```
root@a5aa704a62a5:/app# Stars copy --harvest -conf=/usersettings.json -si CDS -rel -r 4 -v -o ./out /catalog.json
Stars/2.21.0
Loading Plugins
Plugin [AMAZON] injected
Plugin [ASF] injected
Plugin [CDS] injected
Plugin [CDS1] injected
Plugin [CDS2] injected
Plugin [CDS3] injected
Plugin [CDS4] injected
Plugin [CDS5] injected
Plugin [CREO] injected
Plugin [GOOGLE] injected
Plugin [MUNDI] injected
Plugin [ONDA] injected
Plugin [PLANETSCOPE] injected
Plugin [SOBLOO] injected
Plugin [USGS] injected
Plugin [ABAE] injected
Plugin [AIRBUS] injected
Plugin [ALOS2] injected
Plugin [BKA] injected
Plugin [BLACKSKY] injected
Plugin [CONAE] injected
Plugin [CSK] injected
Plugin [DIMAP] injected
Plugin [GAOFEN] injected
Plugin [GAOFEN-3] injected
Plugin [GDAL] injected
Plugin [GEOEYE] injected
Plugin [ICEYE] injected
Plugin [INPE] injected
Plugin [ISRO] injected
Plugin [KANOPUS-V] injected
Plugin [KOMPSAT-3] injected
Plugin [KOMPSAT-5] injected
Plugin [LANDSAT8] injected
Plugin [LANDSAT9] injected
Plugin [NEWSAT] injected
Plugin [PLANET] injected
Plugin [RCM] injected
Plugin [RESURSP] injected
Plugin [SAOCOM] injected
Plugin [SENTINEL-1] injected
Plugin [SENTINEL-2] injected
Plugin [TERRASAR-X] injected
Plugin [WORLDVIEW] injected
Trying to init a root catalog catalog on file:///app/out/
Root catalog catalog created at file:///app/out/catalog.json
Copy node output_stac from file:///catalog.json
The environment variables AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN were not set with AWS credentials.
No configured AWS credentials. Defaulting to instance profile credentials (EC2)
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
ONDA ODATA V2 API identified
Registering extension: atom
Registering extension: json
Registering extension: atom
Registering extension: json
[Copernicus OData search (https://catalogue.dataspace.copernicus.eu/odata/v1)] Searching for file:///catalog.json
Request parameters:
- $filter = Name eq 'output_stac'
- $top = 20
- $expand = Attributes
[Copernicus OData search (https://catalogue.dataspace.copernicus.eu/odata/v1)] --> no supply possible
Extracting asset file:///urn_ogc_def_EOP_CNSA_GF1PMS13271908001-product.tar.gz...
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.dbf
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.rpb
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.rpb.aux.xml
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.rpb.gcp
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.shp
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.shx
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1_thumb.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.tiff
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.xml
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.dbf
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.rpb
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.rpb.aux.xml
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.rpb.gcp
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.shp
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.shx
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1_thumb.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.tiff
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.xml
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001_thumb.jpg
GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001.xml
order.xml
Retrieving the metadata files in the product package
Metadata file is file:///app/out/GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-MSS1.xml
Deserializing metadata files
Metadata files deserialized. Starting metadata generation
Metadata file is file:///app/out/GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001-PAN1.xml
Deserializing metadata files
Metadata files deserialized. Starting metadata generation
Metadata file is file:///app/out/GF1_PMS1_W71.6_S33.2_20240205_L1A13271908001.xml
Deserializing metadata files
Metadata files deserialized. Starting metadata generation
System.ArgumentException: An item with the same key has already been added. Key: file:size
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(KeyValuePair`2 keyValuePair)
   at Stac.StacAccessorsHelpers.AddRange[T](ICollection`1 collection, IEnumerable`1 items)
   at Terradue.Stars.Data.Model.Metadata.Gaofen.GaofenMetadataExtractor.AddAssetAsync(StacItem stacItem, String satelliteId, IAsset asset, IAssetsContainer assetsContainer) in /source/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs:line 268
   at Terradue.Stars.Data.Model.Metadata.Gaofen.GaofenMetadataExtractor.AddAssetsAsync(StacItem stacItem, String satelliteId, IAssetsContainer assetsContainer) in /source/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs:line 192
   at Terradue.Stars.Data.Model.Metadata.Gaofen.GaofenMetadataExtractor.ExtractMetadata(IItem item, String suffix) in /source/src/Stars.Data/Model/Metadata/Gaofen1-2-4/GaofenMetadataExtractor.cs:line 88
   at Terradue.Stars.Data.Model.Metadata.MetadataExtraction.ProcessAsync(IResource resource, IDestination destination, CancellationToken ct, String suffix) in /source/src/Stars.Data/Model/Metadata/MetadataExtraction.cs:line 57
   at Terradue.Stars.Services.Processing.ProcessingService.ExtractMetadataAsync(StacItemNode itemNode, IDestination destination, StacStoreService storeService, CancellationToken ct) in /source/src/Stars.Services/Processing/ProcessingService.cs:line 83
   at Terradue.Stars.Console.Operations.CopyOperation.CopyNodeAsync(IResource node, IRouter router, Object state, CancellationToken ct) in /source/src/Stars.Console/Operations/CopyOperation.cs:line 308
   at Terradue.Stars.Services.Router.RouterService.RouteAsync(IResource route, Int32 recursivity, IRouter prevRouter, Object state, CancellationToken ct) in /source/src/Stars.Services/Router/RouterService.cs:line 78
   at Terradue.Stars.Console.Operations.CopyOperation.ExecuteAsync(CancellationToken ct) in /source/src/Stars.Console/Operations/CopyOperation.cs:line 371
   at Terradue.Stars.Console.Operations.BaseOperation.OnExecuteAsync(CancellationToken ct) in /source/src/Stars.Console/Operations/BaseOperation.cs:line 73
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.InvokeAsync(MethodInfo method, Object instance, Object[] arguments)
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.OnExecute(ConventionContext context, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.Conventions.ExecuteMethodConvention.<>c__DisplayClass0_0.<<Apply>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Terradue.Stars.Console.StarsApp.Main(String[] args) in /source/src/Stars.Console/Stars.cs:line 31
```