### PR TITLE
RCM datasets does not show instrument mode 

### DIFF
--- a/src/Stars.Data.Tests/Resources/CSA/RCM-1/GCD/MetadataExtractorsTests_RCM1_OK1052791_PK1052796_1_3MCP24_20200219_123901_CH_CV_GCD.json
+++ b/src/Stars.Data.Tests/Resources/CSA/RCM-1/GCD/MetadataExtractorsTests_RCM1_OK1052791_PK1052796_1_3MCP24_20200219_123901_CH_CV_GCD.json
@@ -44,9 +44,9 @@
       "sar"
     ],
     "sensor_type": "radar",
-    "title": "RCM-1 GCD HH/VV",
+    "title": "RCM-1 GCD 3M HH/VV",
     "sat:orbit_state": "descending",
-    "sar:instrument_mode": "",
+    "sar:instrument_mode": "3M",
     "sar:frequency_band": "C",
     "sar:polarizations": [
       "HH",

--- a/src/Stars.Data.Tests/Resources/CSA/RCM-2/GRD/MetadataExtractorsTests_RCM2_OK1486596_PK1486712_1_QP26_20210209_124433_HH_VV_HV_VH_GRD.json
+++ b/src/Stars.Data.Tests/Resources/CSA/RCM-2/GRD/MetadataExtractorsTests_RCM2_OK1486596_PK1486712_1_QP26_20210209_124433_HH_VV_HV_VH_GRD.json
@@ -45,9 +45,9 @@
     ],
     "sensor_type": "radar",
     "gsd": 9.0,
-    "title": "RCM-2 GRD HH/HV/VH/VV",
+    "title": "RCM-2 GRD QP26 HH/HV/VH/VV",
     "sat:orbit_state": "ascending",
-    "sar:instrument_mode": "QP",
+    "sar:instrument_mode": "QP26",
     "sar:frequency_band": "C",
     "sar:polarizations": [
       "HH",

--- a/src/Stars.Data.Tests/Resources/CSA/RCM-2/GRD/MetadataExtractorsTests_RCM2_OK2116806_PK2116811_1_16M5_20220605_070317_HH_HV_GRD.json
+++ b/src/Stars.Data.Tests/Resources/CSA/RCM-2/GRD/MetadataExtractorsTests_RCM2_OK2116806_PK2116811_1_16M5_20220605_070317_HH_HV_GRD.json
@@ -44,9 +44,9 @@
       "sar"
     ],
     "sensor_type": "radar",
-    "title": "RCM-2 GRD HH/HV",
+    "title": "RCM-2 GRD 16M HH/HV",
     "sat:orbit_state": "descending",
-    "sar:instrument_mode": "",
+    "sar:instrument_mode": "16M",
     "sar:frequency_band": "C",
     "sar:polarizations": [
       "HH",

--- a/src/Stars.Data.Tests/Resources/CSA/RCM-3/GRD/MetadataExtractorsTests_RCM3_OK1048829_PK1050063_1_FSLCP27_20200215_031403_CH_CV_GRD.json
+++ b/src/Stars.Data.Tests/Resources/CSA/RCM-3/GRD/MetadataExtractorsTests_RCM3_OK1048829_PK1050063_1_FSLCP27_20200215_031403_CH_CV_GRD.json
@@ -44,9 +44,9 @@
       "sar"
     ],
     "sensor_type": "radar",
-    "title": "RCM-3 GRD HH/VV",
+    "title": "RCM-3 GRD FSLCP27 HH/VV",
     "sat:orbit_state": "descending",
-    "sar:instrument_mode": "FSL",
+    "sar:instrument_mode": "FSLCP27",
     "sar:frequency_band": "C",
     "sar:polarizations": [
       "HH",

--- a/src/Stars.Data/Model/Metadata/RCM/RcmMetadataExtractor.cs
+++ b/src/Stars.Data/Model/Metadata/RCM/RcmMetadataExtractor.cs
@@ -217,32 +217,44 @@ namespace Terradue.Stars.Data.Model.Metadata.Rcm
 
         private string GetInstrumentMode(Product auxiliary)
         {
-            switch (auxiliary.SourceAttributes.BeamMode)
-            {
-                case BEAM_MODE.LOW_RESOLUTION_100:
-                    return "SC100";
-                case BEAM_MODE.MEDIUM_RESOLUTION_50:
-                    return "SC50";
-                case BEAM_MODE.MEDIUM_RESOLUTION_30:
-                    return "SC30";
-                case BEAM_MODE.MEDIUM_RESOLUTION_16:
-                    return "16M";
-                case BEAM_MODE.HIGH_RESOLUTION_5:
-                    return "5M";
-                case BEAM_MODE.VERY_HIGH_RESOLUTION_3:
-                    return "3M";
-                case BEAM_MODE.LOW_NOISE:
-                    return "LN";
-                case BEAM_MODE.QUAD_POLARIZATION:
-                    return "QP";
-                case BEAM_MODE.SHIP_DETECTION:
-                    return "SD";
-                case BEAM_MODE.SPOTLIGHT:
-                    return "FSL";
-                default:
-                    return "";
+            // switch (auxiliary.SourceAttributes.BeamMode)
+            // {
+            //     case BEAM_MODE.LOW_RESOLUTION_100:
+            //         return "SC100";
+            //     case BEAM_MODE.MEDIUM_RESOLUTION_50:
+            //         return "SC50";
+            //     case BEAM_MODE.MEDIUM_RESOLUTION_30:
+            //         return "SC30";
+            //     case BEAM_MODE.MEDIUM_RESOLUTION_16:
+            //         return "16M";
+            //     case BEAM_MODE.HIGH_RESOLUTION_5:
+            //         return "5M";
+            //     case BEAM_MODE.VERY_HIGH_RESOLUTION_3:
+            //         return "3M";
+            //     case BEAM_MODE.LOW_NOISE:
+            //         return "LN";
+            //     case BEAM_MODE.QUAD_POLARIZATION:
+            //         return "QP";
+            //     case BEAM_MODE.SHIP_DETECTION:
+            //         return "SD";
+            //     case BEAM_MODE.SPOTLIGHT:
+            //         return "FSL";
+            //     default:
+            //         return "";
+            // }
+            //There are tons of them
+
+            //Take the entire string if no numbers 
+            //That since the beginning to the (eventual) first letter after the number group
+            string inputString = auxiliary.SourceAttributes.BeamModeMnemonic;
+            Match match = Regex.Match(inputString, @"^([^0-9]*\d+[^A-Za-z]*[A-Za-z]?)|([^0-9]+)");
+            if (match.Success) {
+                return match.Groups[1].Value != "" ? match.Groups[1].Value : match.Groups[2].Value;
+            } else {
+                return inputString;
             }
         }
+
         private SarCommonFrequencyBandName GetFrequencyBand(Product auxiliary)
         {
             return SarCommonFrequencyBandName.C; //HARDCODED it is a SAR-C instrument            
@@ -382,10 +394,11 @@ namespace Terradue.Stars.Data.Model.Metadata.Rcm
 
         protected string GetTitle(Product auxiliary, IDictionary<string, object> properties)
         {
-            return string.Format("{0} {1} {2}", 
+            return string.Format("{0} {1} {2} {3}", 
                 //StylePlatform(properties.GetProperty<string>("platform")),
                 properties.GetProperty<string>("platform").ToUpper(),
                 GetProductType(auxiliary),
+                GetInstrumentMode(auxiliary),
                 string.Join("/", GetPolarizations(auxiliary))
             );
         }


### PR DESCRIPTION
ESACPE-1399
RCM datasets do not report the SAR mode [sar:instrument_mode] in the title as per rule:

[platformLabel] [sar:product_type] [sar:instrument_mode] [sar:polarizations] [datetime {ISO8601-TZ}]

In addition the field is empty in the stac Item