### PR TITLE
Unzipped assets again available to metadata extractors

### DIFF
--- a/src/Stars.Console/Operations/CopyOperation.cs
+++ b/src/Stars.Console/Operations/CopyOperation.cs
@@ -314,7 +314,7 @@ namespace Terradue.Stars.Console.Operations
             if (ExtractArchives)
                 stacNode = await processingService.ExtractArchiveAsync(stacItemNode, destination, storeService, ct);
             if (Harvest)
-                stacNode = await processingService.ExtractMetadataAsync(stacItemNode as StacItemNode, destination, storeService, ct);
+                stacNode = await processingService.ExtractMetadataAsync(stacNode as StacItemNode, destination, storeService, ct);
 
             if (AssetsFiltersOut != null && AssetsFiltersOut.Count() > 0)
             {

--- a/src/Stars.Services/Processing/ProcessingService.cs
+++ b/src/Stars.Services/Processing/ProcessingService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -31,9 +32,9 @@ namespace Terradue.Stars.Services.Processing
             Parameters = new ProcessingServiceParameters();
         }
 
-        public async Task<StacNode> ExtractArchiveAsync(StacItemNode stacItemNode, IDestination destination, StacStoreService storeService, CancellationToken ct)
+        public async Task<StacItemNode> ExtractArchiveAsync(StacItemNode stacItemNode, IDestination destination, StacStoreService storeService, CancellationToken ct)
         {
-            StacNode newItemNode = stacItemNode;
+            StacItemNode newItemNode = stacItemNode;
             foreach (var processing in processingManager.GetProcessings(ProcessingType.ArchiveExtractor))
             {
                 if (!processing.CanProcess(newItemNode, destination)) continue;


### PR DESCRIPTION
With this change, a bug (introduced with version 2.24.0) that prevented the metadata extractors from seeing the unzipped assets inside an archive assets was fixed. This led to incorrect metadata harvesting with only generic STAC items rather than platform-specific ones.
